### PR TITLE
1: Add weather-card to install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You must have [HACS](https://hacs.xyz/) installed. Please install the following 
 * `config-template-card`
 * `card-mod`
 * `better-moment-card`
+* `weather-card`
 * `browser_mod` (Required for the popups to work)
 * `layout-card` (Required for the Sections view)
 


### PR DESCRIPTION
Was going through the installation and noticed there's a weather card missing from the instructions, is this the one?

https://github.com/bramkragten/weather-card

Closes #1