### PR TITLE
Replace legacy popup event form with built-in card creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,10 @@ The hardware I originally used I chose based on what I mentioned above plus with
 
 * **Family-wide & Individual Views:** Toggle specific family members' calendars on/off.
 * **Two-way Sync:** Edit events on the screen or on our phones (Google Calendar).
-* **"Add Event" Popup:** A custom UI to add events to specific calendars directly from the screen.
+* **Built-in Event Management:** Create, edit, and delete events directly from the calendar (click "+" on a day or click an existing event).
+* **Multi-view:** Switch between Today, Tomorrow, Week, Biweek, and Month views.
 * **Weather & Date:** Beautiful, glanceable header.
+* **Locale Support:** Set `locale` to display day/month names in your language.
 * **Responsive:** Automatically adjusts day-count based on screen width (Mobile vs Desktop).
 
 ---
@@ -83,19 +85,12 @@ The hardware I originally used I chose based on what I mentioned above plus with
 
 You must have [HACS](https://hacs.xyz/) installed. Please install the following **Frontend** integrations:
 
-* `week-planner-card`
+* `week-planner-card` (v1.15.0+ recommended — includes built-in event creation/editing)
 * `bubble-card`
 * `config-template-card`
 * `card-mod`
 * `better-moment-card`
 * `weather-card`
-* `browser_mod` (Required for the popups to work)
-* `layout-card` (Required for the Sections view)
-* `button-card` (Required for the popup to add event)
-
-*Note: In Settings → Devices & Services, make sure Browser Mod appears as an Integration (tile) and not only under HACS. 
-If it isn’t there, click Add Integration → Browser Mod and finish the flow, then restart HA.
-Installing via HACS only downloads files; you must add the integration so HA registers its actions/entities.
 
 ### 2. The Backend (The Brains)
 
@@ -136,6 +131,21 @@ You can use **Google Calendars** or **Local Calendars**.
 7. Update the entity ID matching your environment
 
 
+#### Customizing the Number of Calendars
+
+By default, the setup includes 4 personal calendars + Family + Birthdays + Holidays. To add or remove calendars:
+
+1. **In `family_calendar.yaml`:** Add/remove a filter entry under `input_text:` and a toggle script under `script:`. Follow the existing pattern (e.g., copy `calendar4_calendar_filter` and its toggle script, rename to `calendar5_calendar_filter`).
+
+2. **In `dashboard.yaml`:**
+   - Add/remove a bubble-card button in the controls section
+   - Add/remove the calendar entity + filter variable in the `config-template-card`
+   - Add/remove the calendar entry under the `week-planner-card` calendars list
+
+3. **In `skylight.yaml` (theme):** Add a color variable for the new calendar (e.g., `calendar5-default-primary-color`).
+
+4. **Restart Home Assistant** after modifying `family_calendar.yaml`.
+
 #### Setting up Holidays
 
 Since Home Assistant updates, Holidays are now added via UI:
@@ -151,6 +161,7 @@ Since Home Assistant updates, Holidays are now added via UI:
 3. On the left menu, select the new created dashboard and click on the pencil icon to edit it.
 5. Select the 3 dots icon and select "Raw configurator editor".
 6. Copy and paste the code from [dashboard.yaml](dashboard.yaml).
+7. To change the language, find `locale: en` and replace with your locale code (e.g., `fr`, `de`, `es`, `nl`). This translates day and month names automatically.
 
 ### Step 5: The Theme (Optional)
 
@@ -181,20 +192,9 @@ The `week-planner-card` does not natively support hiding specific calendars on t
 * When you click a person's button, it toggles their filter between `.*` (Show everything) and `^$` (Show nothing).
 * `config-template-card` injects these variables into the calendar card dynamically.
 
-### Event Creation Script
+### Event Creation
 
-The "Add Event" popup uses a single script that handles logic for multiple people and event types (All Day vs Timed).
-
-```yaml
-# Simplified Logic Example
-target_calendar: "{{ calendar_map.get(states('input_select.calendar_select')) }}"
-
-choose:
-  - conditions: "All Day Event is ON"
-    action: calendar.create_event (start_date, end_date)
-  - conditions: "All Day Event is OFF"
-    action: calendar.create_event (start_date_time, end_date_time)
-```
+Event creation, editing, and deletion are handled directly by the `week-planner-card` (v1.15.0+). Click the "+" button on any day cell to create a new event, or click an existing event to edit or delete it. The `defaultCalendar` option in the card config sets which calendar is pre-selected for new events.
 
 ## NOTES
 

--- a/dashboard.yaml
+++ b/dashboard.yaml
@@ -159,7 +159,6 @@ views:
                     opacity: 1 !important;
                     background-color: ${hass.states['input_text.family_calendar_filter'].state === '.*' ? 'light-grey' : '#4A90E2'} !important;
                   }
-                entity: input_boolean.family_calendar_show
               - type: custom:bubble-card
                 card_type: button
                 button_type: name
@@ -193,29 +192,6 @@ views:
             grid_options:
               columns: 45
               rows: auto
-          - type: markdown
-            content: " "
-            grid_options:
-              columns: 3
-              rows: auto
-          - type: custom:bubble-card
-            card_type: button
-            button_type: name
-            card_layout: large
-            name: Add Event
-            icon: mdi:calendar-plus
-            tap_action:
-              action: navigate
-              navigation_path: "#addcalendarevent"
-            styles: |
-              * { font-size: 1.05em !important; }
-              ha-card { --bubble-main-background-color: #393745 !important; width: 300px; }    
-              .bubble-icon { --mdc-icon-size: 30px !important; color: snow !important; opacity: 1; }
-              .bubble-icon-container { background: #393745 !important; display: flex; }
-              .bubble-name { color: snow !important; opacity: 1; display: flex; line-height: 18px; flex-direction: row; justify-content: center; flex-grow: 1; margin: 0 40px 0 0; pointer-events: none; position: relative; overflow: hidden; }
-            grid_options:
-              columns: 10
-              rows: 1
           - type: custom:bubble-card
             card_type: select
             entity: input_select.calendar_view
@@ -268,6 +244,7 @@ views:
                 })()
             card:
               type: custom:week-planner-card
+              defaultCalendar: calendar.family # <--- UPDATE THIS ENTITY (used for built-in event creation)
               calendars:
                 # --- MAP CALENDARS HERE ---
                 - entity: calendar.calendar1 # <--- UPDATE THIS ENTITY
@@ -545,80 +522,6 @@ views:
               showDescription: false
         column_span: 10
       # --- End CALENDAR SECTION (Week Planner Card) ---
-      # --- START POPUP SECTION (Hidden) ---
-      - type: grid
-        cards:
-          - type: vertical-stack
-            cards:
-              - type: custom:bubble-card
-                card_type: pop-up
-                hash: "#addcalendarevent"
-                button_type: name
-                name: Add Calendar Event
-                icon: mdi:calendar-plus
-                show_icon: true
-                show_name: true
-                styles: |
-                  .bubble-button-card-container {
-                    background: 
-                    ${hass.states['input_select.calendar_select'].state == 'calendar1' ? 'var(--calendar1-default-primary-color)' 
-                    : hass.states['input_select.calendar_select'].state == 'calendar2' ? 'var(--calendar2-default-primary-color)' 
-                    : hass.states['input_select.calendar_select'].state == 'calendar3' ? 'var(--calendar3-default-primary-color)' 
-                    : hass.states['input_select.calendar_select'].state == 'calendar4' ? 'var(--calendar4-default-primary-color)' 
-                    : hass.states['input_select.calendar_select'].state == 'Family' ? 'var(--family-default-primary-color)' 
-                    : 'gray'} !important;
-                  }
-              - type: vertical-stack
-                cards:
-                  - type: entities
-                    entities:
-                      - entity: input_select.calendar_select
-                      - entity: input_text.calendar_event_title
-                        name: Event Title
-                      - entity: input_text.calendar_event_description
-                        name: Event Description
-                      - entity: input_boolean.calendar_all_day_event
-                        name: All Day Event
-                    title: Add Calendar Event
-                    state_color: false
-                  - type: conditional
-                    conditions:
-                      - entity: input_boolean.calendar_all_day_event
-                        state: "off"
-                    card:
-                      type: entities
-                      entities:
-                        - entity: input_datetime.calendar_event_start
-                          name: Start Time
-                        - entity: input_datetime.calendar_event_end
-                          name: End Time
-                  - type: conditional
-                    conditions:
-                      - entity: input_boolean.calendar_all_day_event
-                        state: "on"
-                    card:
-                      type: entities
-                      entities:
-                        - entity: input_datetime.calendar_day_event_start
-                          name: Event Start Date
-                        - entity: input_datetime.calendar_day_event_end
-                          name: Event End Date
-                  - type: custom:button-card
-                    name: Add Event to Calendar
-                    tap_action:
-                      action: call-service
-                      service: script.add_google_calendar_event
-                    styles:
-                      card:
-                        - background-color: |
-                            [[[
-                              if (states['input_select.calendar_select'].state == 'calendar1') return "var(--calendar1-default-primary-color)";
-                              if (states['input_select.calendar_select'].state == 'calendar2') return "var(--calendar2-default-primary-color)";
-                              if (states['input_select.calendar_select'].state == 'calendar3') return "var(--calendar3-default-primary-color)";
-                              if (states['input_select.calendar_select'].state == 'calendar4') return "var(--calendar4-default-primary-color)";
-                              if (states['input_select.calendar_select'].state == 'Family') return "var(--family-default-primary-color)";
-                              return "gray";
-                            ]]]                
     cards: []
     icon: mdi:calendar-blank-multiple
     background:

--- a/packages/family_calendar.yaml
+++ b/packages/family_calendar.yaml
@@ -10,6 +10,9 @@
 # ==============================================================================
 
 # 1. HELPERS (The Variables)
+# To add a new calendar: copy a filter entry below and its matching toggle
+# script, then update dashboard.yaml to reference it.
+# To remove a calendar: delete its filter entry and toggle script.
 input_text:
   # Filter Toggles (RegEx: .* = Show, ^$ = Hide)
   calendar1_calendar_filter:

--- a/packages/family_calendar.yaml
+++ b/packages/family_calendar.yaml
@@ -3,7 +3,7 @@
 # ==============================================================================
 #  INSTRUCTIONS:
 #  1. Place this file in your /config/packages/ folder.
-#  2. Ensure your configuration.yaml has: 
+#  2. Ensure your configuration.yaml has:
 #     homeassistant:
 #       packages: !include_dir_named packages
 #  3. RESTART Home Assistant.
@@ -34,26 +34,7 @@ input_text:
     name: Holidays Filter
     initial: ".*"
 
-  # Event Form Data
-  calendar_event_title:
-    name: Event Title
-    icon: mdi:format-title
-  calendar_event_description:
-    name: Event Description
-    icon: mdi:text
-
 input_select:
-  # The dropdown list for "Who is this event for?"
-  calendar_select:
-    name: Select Calendar
-    options:
-      - calendar1
-      - calendar2
-      - calendar3
-      - calendar4
-      - Family
-    icon: mdi:calendar-check
-  
   # The View selector (Week, Month, etc)
   calendar_view:
     name: Calendar View
@@ -64,29 +45,6 @@ input_select:
       - Biweek
       - Month
     initial: Week
-
-input_datetime:
-  # Event start/end times
-  calendar_event_start:
-    has_date: true
-    has_time: true
-  calendar_event_end:
-    has_date: true
-    has_time: true
-  calendar_day_event_start:
-    has_date: true
-    has_time: false
-  calendar_day_event_end:
-    has_date: true
-    has_time: false
-
-input_boolean:
-  # UI Toggles
-  calendar_all_day_event:
-    name: All Day Event
-    icon: mdi:calendar-clock
-  family_calendar_show:
-    name: Show Family Calendar
 
 # 2. SCRIPTS (The Logic)
 script:
@@ -153,67 +111,3 @@ script:
           entity_id: input_text.holidays_calendar_filter
         data:
           value: "{% if is_state('input_text.holidays_calendar_filter', '.*') %}^${% else %}.*{% endif %}"
-
-  # --- Add Event Logic ---
-  add_google_calendar_event:
-    alias: Process Add Calendar Event
-    sequence:
-      - variables:
-          # ====================================================================
-          # CONFIGURATION: ENTITY MAPPING
-          # Map the Dropdown Name (Left) to your Entity ID (Right).
-          # ====================================================================
-          calendar_map:
-            "calendar1": "calendar.calendar1" #<--- UPDATE THIS ENTITY
-            "calendar2": "calendar.calendar2" #<--- UPDATE THIS ENTITY
-            "calendar3": "calendar.calendar3" #<--- UPDATE THIS ENTITY
-            "calendar4": "calendar.calendar4" #<--- UPDATE THIS ENTITY
-            "Family": "calendar.family" #<--- UPDATE THIS ENTITY
-          
-          # Selects the entity based on the map above
-          target_calendar: "{{ calendar_map.get(states('input_select.calendar_select'), 'calendar.family') }}" #<--- UPDATE THIS ENTITY
-
-      - choose:
-          # Scenario A: All Day Event
-          - conditions:
-              - condition: state
-                entity_id: input_boolean.calendar_all_day_event
-                state: "on"
-            sequence:
-              - action: calendar.create_event
-                target:
-                  entity_id: "{{ target_calendar }}"
-                data:
-                  summary: "{{ states('input_text.calendar_event_title') }}"
-                  description: "{{ states('input_text.calendar_event_description') }}"
-                  start_date: "{{ states('input_datetime.calendar_day_event_start') }}"
-                  end_date: "{{ states('input_datetime.calendar_day_event_end') }}"
-          
-          # Scenario B: Timed Event
-          - conditions:
-              - condition: state
-                entity_id: input_boolean.calendar_all_day_event
-                state: "off"
-            sequence:
-              - action: calendar.create_event
-                target:
-                  entity_id: "{{ target_calendar }}"
-                data:
-                  summary: "{{ states('input_text.calendar_event_title') }}"
-                  description: "{{ states('input_text.calendar_event_description') }}"
-                  start_date_time: "{{ states('input_datetime.calendar_event_start') }}"
-                  end_date_time: "{{ states('input_datetime.calendar_event_end') }}"
-
-      # Cleanup and Close
-      - action: input_text.set_value
-        target:
-          entity_id: input_text.calendar_event_title
-        data:
-          value: ""
-      - action: input_text.set_value
-        target:
-          entity_id: input_text.calendar_event_description
-        data:
-          value: ""
-      - action: browser_mod.close_popup
-        data: {}


### PR DESCRIPTION
## Summary

- Remove the legacy popup-based event creation form (bubble-card popup, input helpers, scripts)
- Add `defaultCalendar` config option to week-planner-card for built-in event creation
- Reduce `family_calendar.yaml` from 219 to 112 lines (removed 10 unused entities and 1 script)

## Why

The [week-planner-card](https://github.com/FamousWolf/week-planner-card) now supports **built-in event creation, editing, and deletion** directly from the calendar UI (click "+" on a day cell, or click an event to edit/delete). This makes the old popup form with `input_select`, `input_datetime`, `input_boolean`, and `input_text` helpers unnecessary.

## What's removed

**Entities (from `family_calendar.yaml`):**
- `input_text.calendar_event_title`
- `input_text.calendar_event_description`
- `input_select.calendar_select`
- `input_datetime.calendar_event_start` / `calendar_event_end`
- `input_datetime.calendar_day_event_start` / `calendar_day_event_end`
- `input_boolean.calendar_all_day_event`
- `input_boolean.family_calendar_show`
- `script.add_google_calendar_event`

**Dashboard (from `dashboard.yaml`):**
- "Add Event" button
- `#addcalendarevent` popup section (bubble-card pop-up with form)

## What's added

- `defaultCalendar` config option on the week-planner-card (sets default calendar for new events)

## Test plan

- [ ] Verify calendar filter toggles still work
- [ ] Verify view selector (Today/Week/Month) still works
- [ ] Verify event creation via the built-in "+" button on day cells
- [ ] Verify event editing/deletion by clicking on existing events


🤖 Generated with [Claude Code](https://claude.com/claude-code)